### PR TITLE
Removed / from parameter names

### DIFF
--- a/shsa/publish-model.conf
+++ b/shsa/publish-model.conf
@@ -979,7 +979,7 @@ publish {
 				}
 			}
 			{
-				name=F/T-sensor_readout
+				name=FT-sensor_readout
 				description="F/T sensor readout (Tx,Ty,Tz,Rx,Ry,Rz) (latest value)"
 				type=array
 				dimensions:	[6]
@@ -988,7 +988,7 @@ publish {
 				}
 			}
 			{
-				name=F/T-sensor_force_on_F/T
+				name=FT-sensor_force_on_FT
 				description="F/T sensor (Tx,Ty,Tz,Rx,Ry,Rz) (moving averaged value) on F/T"
 				type=array
 				dimensions:	[6]
@@ -998,7 +998,7 @@ publish {
 				units=newton
 			}
 			{
-				name=F/T-sensor_force
+				name=FT-sensor_force
 				description="F/T sensor (Tx,Ty,Tz,Rx,Ry,Rz) (moving averaged value) on TBFCRS"
 				type=array
 				dimensions:	[6]
@@ -1137,7 +1137,7 @@ publish {
 				}
 			}
 			{
-				name=F/T-sensor_force_relative
+				name=FT-sensor_force_relative
 				description="F/T sensor (Tx,Ty,Tz,Rx,Ry,Rz) (moving averaged value) relative value from 0 reset timing on each phase of Compliance-Control"
 				type=array
 				dimensions:	[6]
@@ -1147,7 +1147,7 @@ publish {
 				units=newton
 			}
 			{
-				name=F/T-sensor_force_demand_CC
+				name=FT-sensor_force_demand_CC
 				description="F/T command (Tx,Ty,Tz,Rx,Ry,Rz) value by Compliance-Control"
 				type=array
 				dimensions:	[6]


### PR DESCRIPTION
I removed the "/" from "F/T" parameter names in the diagnostic event in the SHA assembly.  This character was disallowed because of work we had done in the DMS FITS dictionary prototype.  The CSW documentation has not been updated yet.  